### PR TITLE
Redesign sim_ES output to structured effect_size_data; add calc_dist and balanced_sampling_es; update plotting and inferential returns

### DIFF
--- a/R/sim_es.R
+++ b/R/sim_es.R
@@ -105,6 +105,10 @@ sim_ES <- function(
   model = "single.factor",
   jitter.base = 0.5
 ) {
+  if (model != "single.factor") {
+    stop("`sim_ES()` currently supports only `model = 'single.factor'`. Nested designs are not implemented yet.")
+  }
+
   # read data and store it in two objects, one for H0 and one for Ha ----
   datH0 <- data
   datH0[, 1] <- as.factor("zero")
@@ -142,9 +146,9 @@ sim_ES <- function(
   ## Calculate species similarity percentage from Ha ----
   sppContribution <- use_simper(datHa)
 
-  ## Output matrix ----
-  resultOut <- matrix(NA_real_, nrow = NN * (steps + 1), ncol = 5)
-  colnames(resultOut) <- c("step", "m", "n", "FobsH0", "FobsHa")
+  ## Output container ----
+  resultOut <- vector("list", length = NN * (steps + 1))
+  pcoaOut <- vector("list", length = NN * (steps + 1))
 
   simH0 <- SSP::simdata(
     parH0,
@@ -231,7 +235,7 @@ sim_ES <- function(
 
     HaSim <- array(unlist(HaSim), dim = c(xH0, yH0, casesHa))
 
-    # Loop to calculate pseudoF and SS ----
+    # Loop to calculate ecological and inferential effect sizes ----
 
     if (useParallel) {
       # Registering the cluster of workers with parabar
@@ -245,7 +249,11 @@ sim_ES <- function(
       # Exporing functions needed for the parallel iterations
       parabar::export(
         cl,
-        variables = c("balanced_sampling", "dbmanova_oneway", "SS"),
+        variables = c(
+          "balanced_sampling_es",
+          "dbmanova_oneway",
+          "calc_dist"
+        ),
         environment = asNamespace("ecocbo")
       )
 
@@ -253,72 +261,111 @@ sim_ES <- function(
       result1 <- parabar::par_lapply(
         cl,
         x = 1:NN,
-        fun = balanced_sampling,
+        fun = balanced_sampling_es,
         Y,
         mm,
         nn,
         YPU,
-        H0Sim,
         HaSim,
         resultsHa,
         transformation,
         method
-      ) |>
-        unlist() |>
-        matrix(ncol = 7, byrow = TRUE)
-      colnames(result1) <- c(
-        "FobsH0",
-        "FobsHa",
-        "MSA",
-        "MSR",
-        "SSf",
-        "SSr",
-        "SSt"
       )
 
-      # Assigning the results to the outcome matrix
-      resultsHa[, c("FobsHa", "FobsH0")] <- result1[, c("FobsHa", "FobsH0")]
-
       parabar::stop_backend(cl)
-      rm(result1)
     } else {
       pb <- txtProgressBar(max = NN, style = 3)
+      result1 <- vector("list", length = NN)
 
       for (i in seq_len(NN)) {
         # Performs the operation iteratively in a for loop
-        result1 <- balanced_sampling(
+        result1[[i]] <- balanced_sampling_es(
           i,
           Y,
           mm,
           nn,
           YPU,
-          H0Sim,
           HaSim,
           resultsHa,
           transformation,
           method
         )
-        # Assigning results to the results matrix
-        resultsHa[i, c("FobsHa", "FobsH0")] <- result1[, c("FobsHa", "FobsH0")]
 
         # Updating the progress bar
         setTxtProgressBar(pb, i)
       }
-      rm(result1)
       close(pb)
     }
 
     idx <- (st * NN + 1):((st + 1) * NN)
+    tmp <- lapply(seq_len(NN), function(i) {
+      cur <- result1[[i]]
+      row <- data.frame(
+        reduction_level = st / steps,
+        step = st,
+        dat_sim = resultsHa[i, "dat.sim"],
+        k = resultsHa[i, "k"],
+        m = resultsHa[i, "m"],
+        n = resultsHa[i, "n"],
+        ecological_effect = cur$ecological_effect,
+        omega2 = cur$omega2,
+        R2 = cur$R2,
+        pseudoF = cur$pseudoF,
+        SS_between = cur$SS_between,
+        SS_total = cur$SS_total,
+        df_between = cur$df_between,
+        MS_residual = cur$MS_residual,
+        n_groups = cur$n_groups,
+        stringsAsFactors = FALSE
+      ) |>
+        dplyr::mutate(
+          centroid_dist_matrix = list(cur$centroid_dist_matrix),
+          infer_table = list(cur$infer_table)
+        )
 
-    resultOut[idx, 1] <- st
-    resultOut[idx, 2:5] <- resultsHa[, c("m", "n", "FobsH0", "FobsHa")]
+      pcoa_i <- cur$pcoa_points |>
+        dplyr::mutate(
+          reduction_level = row$reduction_level,
+          step = row$step
+        ) |>
+        dplyr::select(
+          reduction_level,
+          step,
+          dat_sim,
+          k,
+          m,
+          n,
+          group,
+          Axis1,
+          Axis2
+        )
+
+      list(row = row, pcoa = pcoa_i)
+    })
+    resultOut[idx] <- lapply(tmp, `[[`, "row")
+    pcoaOut[idx] <- lapply(tmp, `[[`, "pcoa")
 
     cat("Step ", st, ": Done! - ", steps - st, " remaining")
   }
 
-  class(resultOut) <- c("effect_size_data", class(resultOut))
+  resultOut <- dplyr::bind_rows(resultOut)
+  pcoaOut <- dplyr::bind_rows(pcoaOut)
+  pcoa_meta <- pcoaOut |>
+    dplyr::group_by(reduction_level, step, dat_sim, k, m, n, group) |>
+    dplyr::summarise(
+      Axis1 = mean(Axis1, na.rm = TRUE),
+      Axis2 = mean(Axis2, na.rm = TRUE),
+      .groups = "drop"
+    )
 
-  return(resultOut)
+  es_obj <- new_effect_size_data(
+    resultOut,
+    pcoa = pcoaOut,
+    pcoa_meta = pcoa_meta,
+    call = match.call()
+  )
+
+  return(es_obj)
 }
 
 
@@ -335,31 +382,96 @@ sim_ES <- function(
 #' @return A ggplot representation of the \code{effect_size_data} object.
 #' @export
 
-plot.effect_size_data <- function(x, ...) {
-  p1 <- x |>
-    as.data.frame() |>
-    dplyr::mutate(removed = step / max(step), ES = FobsHa - FobsH0) |>
-    dplyr::group_by(removed) |>
-    dplyr::summarise(
-      media = mean(ES, na.rm = TRUE),
-      mediana = median(ES, na.rm = TRUE),
-      q25 = quantile(ES, 0.25, na.rm = TRUE),
-      q75 = quantile(ES, 0.75, na.rm = TRUE),
-      .groups = "drop"
-    ) |>
-    ggplot2::ggplot(ggplot2::aes(x = removed, y = media)) +
-    ggplot2::geom_ribbon(ggplot2::aes(ymin = q25, ymax = q75), alpha = 0.3) +
-    ggplot2::geom_line() +
-    ggplot2::geom_point() +
-    ggplot2::scale_x_continuous(name = "% removed SIMPER contribution") +
-    ggplot2::scale_y_continuous(name = "FHa - FH0") +
-    ggplot2::theme_bw() +
-    ggplot2::theme(
-      panel.grid.minor.x = ggplot2::element_blank(),
-      panel.border = ggplot2::element_rect(linewidth = 0.4),
-      axis.ticks = ggplot2::element_line(linewidth = 0.2)
-    )
+plot.effect_size_data <- function(x, type = c("summary", "ordination"), ...) {
+  if (!all(c("reduction_level", "ecological_effect") %in% colnames(x))) {
+    stop("`plot.effect_size_data()` expects redesigned output from `sim_ES()`.")
+  }
+  type <- match.arg(type)
 
-  print(p1)
-  invisible(p1)
+  if (type == "summary") {
+    p1 <- x |>
+      as.data.frame() |>
+      dplyr::group_by(reduction_level) |>
+      dplyr::summarise(
+        media = mean(ecological_effect, na.rm = TRUE),
+        mediana = median(ecological_effect, na.rm = TRUE),
+        q25 = quantile(ecological_effect, 0.25, na.rm = TRUE),
+        q75 = quantile(ecological_effect, 0.75, na.rm = TRUE),
+        .groups = "drop"
+      ) |>
+      ggplot2::ggplot(ggplot2::aes(x = reduction_level, y = media)) +
+      ggplot2::geom_ribbon(ggplot2::aes(ymin = q25, ymax = q75), alpha = 0.3) +
+      ggplot2::geom_line() +
+      ggplot2::geom_point() +
+      ggplot2::scale_x_continuous(name = "% removed SIMPER contribution") +
+      ggplot2::scale_y_continuous(name = "Ecological effect size") +
+      ggplot2::theme_bw() +
+      ggplot2::theme(
+        panel.grid.minor.x = ggplot2::element_blank(),
+        panel.border = ggplot2::element_rect(linewidth = 0.4),
+        axis.ticks = ggplot2::element_line(linewidth = 0.2)
+      )
+    print(p1)
+    return(invisible(p1))
+  }
+
+  pcoa <- attr(x, "pcoa")
+  if (is.null(pcoa) || !is.data.frame(pcoa)) {
+    stop("`attr(x, 'pcoa')` with sample coordinates is required for `type = 'ordination'`.")
+  }
+
+  meta <- as.data.frame(x) |>
+    dplyr::group_by(reduction_level) |>
+    dplyr::summarise(target = stats::median(ecological_effect, na.rm = TRUE), .groups = "drop")
+
+  sel <- as.data.frame(x) |>
+    dplyr::inner_join(meta, by = "reduction_level") |>
+    dplyr::mutate(delta = abs(ecological_effect - target)) |>
+    dplyr::group_by(reduction_level) |>
+    dplyr::slice_min(order_by = delta, n = 1, with_ties = FALSE) |>
+    dplyr::ungroup() |>
+    dplyr::select(reduction_level, step, dat_sim, k, m, n)
+
+  ord_df <- pcoa |>
+    dplyr::inner_join(sel, by = c("reduction_level", "step", "dat_sim", "k", "m", "n"))
+
+  cent <- ord_df |>
+    dplyr::group_by(reduction_level, group) |>
+    dplyr::summarise(Axis1 = mean(Axis1), Axis2 = mean(Axis2), .groups = "drop")
+
+  p_ord <- ggplot2::ggplot(ord_df, ggplot2::aes(x = Axis1, y = Axis2, colour = group)) +
+    ggplot2::geom_point(alpha = 0.7) +
+    ggplot2::geom_point(
+      data = cent,
+      ggplot2::aes(x = Axis1, y = Axis2, colour = group),
+      shape = 4,
+      size = 2.8,
+      inherit.aes = FALSE
+    ) +
+    ggplot2::facet_wrap(~ reduction_level, scales = "free") +
+    ggplot2::coord_equal() +
+    ggplot2::theme_bw() +
+    ggplot2::labs(x = "PCoA 1", y = "PCoA 2", colour = "Group")
+
+  print(p_ord)
+  invisible(p_ord)
+}
+
+#' Constructor for effect_size_data objects
+#'
+#' @param data Main summary table.
+#' @param pcoa Optional long table with PCoA sample points.
+#' @param pcoa_meta Optional aggregated PCoA metadata.
+#' @param call Optional call.
+#'
+#' @return A data.frame with class `effect_size_data`.
+#' @keywords internal
+#' @noRd
+new_effect_size_data <- function(data, pcoa = NULL, pcoa_meta = NULL, call = NULL) {
+  out <- as.data.frame(data, stringsAsFactors = FALSE)
+  class(out) <- c("effect_size_data", class(out))
+  attr(out, "pcoa") <- pcoa
+  attr(out, "pcoa_meta") <- pcoa_meta
+  attr(out, "call") <- call
+  out
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -170,6 +170,13 @@ dbmanova_oneway <- function(
     df = c(dfA = dfA, dfR = dfR, dfT = dfT),
     MS = c(MS_A = MS_A, MS_R = MS_R),
     F = c(F_A = F_A),
+    SS_between = SSA,
+    SS_total = SST,
+    df_between = dfA,
+    MS_residual = MS_R,
+    pseudoF = F_A,
+    R2 = SSA / SST,
+    omega2 = (SSA - dfA * MS_R) / (SST + MS_R),
     method = method,
     transformation = transformation,
     model = model
@@ -180,6 +187,100 @@ dbmanova_oneway <- function(
     table = anova_tbl,
     list = out_list,
     both = list(table = anova_tbl, stats = out_list)
+  )
+}
+
+#' Balanced sampling for effect size simulations
+#'
+#' Builds one balanced sample and computes ecological and inferential effect sizes.
+#'
+#' @param i Integer. Iteration index.
+#' @param Y Integer vector/matrix with row indices to sample from.
+#' @param mm Integer vector with number of groups in each iteration.
+#' @param nn Integer vector with total sample size in each iteration.
+#' @param YPU Integer vector labeling PSUs for balanced sampling.
+#' @param HaSim 3D array of simulated Ha communities.
+#' @param resultsHa Helper matrix with labels (at least dat.sim, k, m, n).
+#' @param transformation Character. Data transformation.
+#' @param method Character. Dissimilarity metric.
+#'
+#' @return A named list with one-row metrics for the selected simulation/sample.
+#'
+#' @keywords internal
+#' @noRd
+balanced_sampling_es <- function(
+  i,
+  Y,
+  mm,
+  nn,
+  YPU,
+  HaSim,
+  resultsHa,
+  transformation,
+  method
+) {
+  m <- mm[i]
+  n <- nn[i]
+
+  df_idx <- tibble::tibble(
+    idx = seq_along(Y),
+    PU = YPU
+  )
+
+  psu_sel <- df_idx |>
+    dplyr::distinct(PU) |>
+    dplyr::slice_sample(n = m) |>
+    dplyr::pull(PU)
+
+  sel_rows <- df_idx |>
+    dplyr::filter(PU %in% psu_sel) |>
+    dplyr::group_by(PU) |>
+    dplyr::slice_sample(n = n / m) |>
+    dplyr::ungroup() |>
+    dplyr::pull(idx)
+
+  sel <- matrix(0L, nrow = nrow(df_idx), ncol = 1)
+  sel[sel_rows, 1] <- 1L
+  ones <- which(sel[, 1] %in% 1)
+
+  ya <- HaSim[ones, , resultsHa[i, 1]]
+  yHa <- dim(ya)[2] - 2
+
+  infer_out <- dbmanova_oneway(
+    x = ya[, 1:yHa],
+    factEnv = ya[, yHa + 2],
+    transformation = transformation,
+    method = method,
+    return = "both"
+  )
+
+  eco <- calc_dist(
+    datHa = cbind(group = ya[, yHa + 2], ya[, 1:yHa, drop = FALSE]),
+    method = method,
+    return = "both"
+  )
+
+  pcoa_points <- eco$pcoa_points |>
+    dplyr::mutate(
+      dat_sim = resultsHa[i, "dat.sim"],
+      k = resultsHa[i, "k"],
+      m = resultsHa[i, "m"],
+      n = resultsHa[i, "n"]
+    )
+
+  list(
+    pseudoF = infer_out$stats$pseudoF,
+    omega2 = infer_out$stats$omega2,
+    R2 = infer_out$stats$R2,
+    SS_between = infer_out$stats$SS_between,
+    SS_total = infer_out$stats$SS_total,
+    df_between = infer_out$stats$df_between,
+    MS_residual = infer_out$stats$MS_residual,
+    ecological_effect = eco$ecological_effect,
+    centroid_dist_matrix = eco$centroid_dist_matrix,
+    n_groups = eco$n_groups,
+    infer_table = infer_out$table,
+    pcoa_points = pcoa_points
   )
 }
 
@@ -934,21 +1035,73 @@ use_simper <- function(datHa) {
 #' @noRd
 #'
 
-calc_dist <- function(datHa) {
-  datHa_site <- datHa[, 1]
-  datHa_ <- datHa[, c(2:(ncol(datHa)))]
-  # Calculates global Bray-Curtis
-  DistBC <- vegan::vegdist(datHa_)
-  # PCoA and corrected cmdscale
-  ord <- vegan::wcmdscale(DistBC, eig = TRUE, add = "lingoes")
-  # Samples coordinates
-  coords <- as.data.frame(ord$points)
-  coords$site <- datHa_site
-  # Group centroids
-  centroides <- aggregate(. ~ site, data = coords, FUN = mean)
-  # Distances between centroids
-  dist_centroides <- dist(centroides[, -1]) |>
-    as.matrix()
+calc_dist <- function(datHa, method = "bray", return = c("matrix", "both")) {
+  return <- match.arg(return)
+  datHa_site <- as.factor(datHa[, 1])
+  datHa_ <- datHa[, c(2:(ncol(datHa))), drop = FALSE]
 
-  return(dist_centroides)
+  DistBC <- vegan::vegdist(datHa_, method = method)
+  ord <- vegan::wcmdscale(DistBC, eig = TRUE, add = "lingoes")
+
+  eig <- ord$eig
+  eig_pos <- which(eig > 0)
+  coords <- as.data.frame(ord$points[, eig_pos, drop = FALSE])
+  coords$site <- datHa_site
+
+  # 2-axis view used for ordination plotting (analytical ES still uses all + axes)
+  if (ncol(coords) == 0) {
+    pcoa_points <- data.frame(
+      group = datHa_site,
+      Axis1 = rep(0, nrow(datHa_)),
+      Axis2 = rep(0, nrow(datHa_))
+    )
+  } else if (ncol(coords) == 1) {
+    pcoa_points <- data.frame(
+      group = datHa_site,
+      Axis1 = coords[[1]],
+      Axis2 = rep(0, nrow(coords))
+    )
+  } else {
+    pcoa_points <- data.frame(
+      group = datHa_site,
+      Axis1 = coords[[1]],
+      Axis2 = coords[[2]]
+    )
+  }
+
+  centroides <- stats::aggregate(. ~ site, data = coords, FUN = mean)
+  centroid_dist <- stats::dist(centroides[, -1, drop = FALSE]) |>
+    as.matrix()
+  rownames(centroid_dist) <- centroides$site
+  colnames(centroid_dist) <- centroides$site
+
+  n_groups <- nlevels(datHa_site)
+  group_size <- as.numeric(table(datHa_site))
+  centroid_mat <- as.matrix(centroides[, -1, drop = FALSE])
+
+  ecological_effect <- if (n_groups == 2) {
+    as.numeric(centroid_dist[1, 2])
+  } else {
+    c_bar <- colMeans(centroid_mat)
+    sq_dist <- rowSums((centroid_mat - matrix(
+      c_bar,
+      nrow = nrow(centroid_mat),
+      ncol = ncol(centroid_mat),
+      byrow = TRUE
+    ))^2)
+    sqrt(sum(group_size * sq_dist) / sum(group_size))
+  }
+
+  if (return == "matrix") {
+    return(centroid_dist)
+  }
+
+  list(
+    ecological_effect = ecological_effect,
+    centroid_dist_matrix = centroid_dist,
+    centroids = centroides,
+    n_groups = n_groups,
+    positive_axes = eig_pos,
+    pcoa_points = pcoa_points
+  )
 }

--- a/tests/testthat/test-sim_ES_redesign.R
+++ b/tests/testthat/test-sim_ES_redesign.R
@@ -1,0 +1,135 @@
+data("epiDat")
+
+test_that("calc_dist uses centroid distance when there are exactly 2 groups", {
+  set.seed(123)
+  toy <- data.frame(
+    grp = factor(rep(c("A", "B"), each = 6)),
+    sp1 = c(rpois(6, 8), rpois(6, 2)),
+    sp2 = c(rpois(6, 1), rpois(6, 7)),
+    sp3 = c(rpois(6, 3), rpois(6, 5))
+  )
+
+  out <- ecocbo:::calc_dist(toy, return = "both")
+  expect_equal(out$n_groups, 2)
+  expect_equal(out$ecological_effect, as.numeric(out$centroid_dist_matrix[1, 2]))
+})
+
+test_that("calc_dist uses weighted global RMS when groups are > 2", {
+  set.seed(123)
+  toy <- data.frame(
+    grp = factor(rep(c("A", "B", "C"), each = 5)),
+    sp1 = c(rpois(5, 8), rpois(5, 2), rpois(5, 4)),
+    sp2 = c(rpois(5, 1), rpois(5, 7), rpois(5, 4)),
+    sp3 = c(rpois(5, 3), rpois(5, 5), rpois(5, 6))
+  )
+
+  out <- ecocbo:::calc_dist(toy, return = "both")
+  cent <- as.matrix(out$centroids[, -1, drop = FALSE])
+  wg <- as.numeric(table(toy$grp))
+  cbar <- colMeans(cent)
+  sqd <- rowSums((cent - matrix(cbar, nrow = nrow(cent), ncol = ncol(cent), byrow = TRUE))^2)
+  expected <- sqrt(sum(wg * sqd) / sum(wg))
+
+  expect_equal(out$n_groups, 3)
+  expect_equal(out$ecological_effect, expected, tolerance = 1e-10)
+  expect_equal(dim(out$centroid_dist_matrix), c(3, 3))
+})
+
+test_that("dbmanova_oneway exposes inferential components and formulas", {
+  toy <- data.frame(
+    sp1 = c(8, 7, 9, 2, 1, 3),
+    sp2 = c(1, 2, 0, 8, 7, 9),
+    sp3 = c(3, 4, 2, 5, 6, 7)
+  )
+  grp <- factor(rep(c("A", "B"), each = 3))
+
+  out <- ecocbo:::dbmanova_oneway(toy, grp, return = "list")
+  expect_equal(out$R2, out$SS_between / out$SS_total)
+  expect_equal(
+    out$omega2,
+    (out$SS_between - out$df_between * out$MS_residual) /
+      (out$SS_total + out$MS_residual)
+  )
+})
+
+test_that("sim_ES returns redesigned columns and stores centroid distances", {
+  set.seed(12)
+  es <- sim_ES(
+    data = epiDat,
+    steps = 2,
+    type = "counts",
+    Sest.method = "average",
+    cases = 2,
+    N = 20,
+    n = 4,
+    k = 2,
+    transformation = "none",
+    method = "bray",
+    dummy = FALSE,
+    useParallel = FALSE,
+    model = "single.factor",
+    jitter.base = 0
+  )
+
+  required_cols <- c(
+    "reduction_level", "k", "m", "n",
+    "ecological_effect", "omega2", "R2", "pseudoF",
+    "centroid_dist_matrix"
+  )
+  expect_true(all(required_cols %in% colnames(es)))
+  expect_true(all(vapply(es$centroid_dist_matrix, is.matrix, logical(1))))
+  expect_true(inherits(es, "effect_size_data"))
+  pcoa <- attr(es, "pcoa")
+  expect_true(is.data.frame(pcoa))
+  expect_true(all(c(
+    "reduction_level", "step", "dat_sim", "k", "m", "n",
+    "group", "Axis1", "Axis2"
+  ) %in% names(pcoa)))
+})
+
+test_that("sim_ES blocks nested model in redesigned pipeline", {
+  expect_error(
+    sim_ES(
+      data = epiDat,
+      steps = 1,
+      cases = 1,
+      N = 10,
+      n = 3,
+      k = 1,
+      useParallel = FALSE,
+      model = "nested.symmetric"
+    ),
+    "not implemented"
+  )
+})
+
+test_that("balanced_sampling legacy signature is preserved for prep_data compatibility", {
+  expected <- c(
+    "i", "Y", "mm", "nn", "YPU", "H0Sim", "HaSim", "resultsHa",
+    "transformation", "method"
+  )
+  expect_equal(names(formals(ecocbo:::balanced_sampling)), expected)
+})
+
+test_that("effect_size_data supports ordination plotting using saved PCoA", {
+  set.seed(7)
+  es <- sim_ES(
+    data = epiDat,
+    steps = 1,
+    type = "counts",
+    Sest.method = "average",
+    cases = 1,
+    N = 16,
+    n = 4,
+    k = 1,
+    transformation = "none",
+    method = "bray",
+    dummy = FALSE,
+    useParallel = FALSE,
+    model = "single.factor",
+    jitter.base = 0
+  )
+
+  p <- plot(es, type = "ordination")
+  expect_s3_class(p, "ggplot")
+})


### PR DESCRIPTION
### Motivation

- Provide a richer, structured output for simulations that includes ecological effect estimates and PCoA coordinates for ordination visualization.
- Compute and surface both inferential statistics and ecological effect sizes in a single pipeline to simplify downstream analyses and plotting.
- Prepare the code for a redesigned plotting API that can show summary trajectories and ordination snapshots using stored PCoA results.

### Description

- Reworked `sim_ES()` to only support `model = "single.factor"` for the redesigned pipeline and to collect per-simulation metrics into a tidy `data.frame` returned as an `effect_size_data` object via `new_effect_size_data()`; PCoA sample points are stored in the `pcoa` attribute and aggregated PCoA meta in `pcoa_meta`.
- Added `balanced_sampling_es()` which builds a balanced sample from simulated data and returns a named list with inferential outputs and ecological metrics, and switched parallel and sequential loops to use this worker function.
- Extended `dbmanova_oneway()` return values to expose `SS_between`, `SS_total`, `df_between`, `MS_residual`, `pseudoF`, `R2`, and `omega2` for easier downstream consumption.
- Rewrote `calc_dist()` to accept `method` and `return` arguments, compute PCoA coordinates, centroid distance matrix, and an analytical `ecological_effect` (pairwise centroid distance for 2 groups or weighted RMS for >2 groups), and return both matrix and richer lists including `pcoa_points` for plotting.
- Updated `plot.effect_size_data()` to support two modes via `type = c("summary","ordination")`: a summary trajectory plot of ecological effect across removal levels and an ordination snapshot using stored PCoA points; legacy plotting expectations are validated and errors produced for incompatible objects.
- Added `new_effect_size_data()` constructor to attach `pcoa`, `pcoa_meta`, and `call` attributes while preserving S3 class `effect_size_data`.
- Added comprehensive tests in `tests/testthat/test-sim_ES_redesign.R` covering `calc_dist()`, `dbmanova_oneway()` internals, the redesigned `sim_ES()` output shape and attributes, the model guard, compatibility of legacy `balanced_sampling` signature, and ordination plotting using the saved PCoA.

### Testing

- Added `tests/testthat/test-sim_ES_redesign.R` and executed the test suite with `devtools::test()`; all new tests passed.
- Unit tests verify `calc_dist()` behavior for 2 and >2 groups and check inferred formulas from `dbmanova_oneway()` and the structure/attributes of `sim_ES()` output, and these assertions succeeded.
- The ordination plotting mode of `plot.effect_size_data()` is exercised in tests and returns a `ggplot` object as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d93bca4c348320b6904563fe69d6e7)