### PR TITLE
Add nested.symmetric support to sim_ES with hierarchical ecological metrics and tests

### DIFF
--- a/R/sim_es.R
+++ b/R/sim_es.R
@@ -87,6 +87,201 @@
 #' ES1
 #'
 
+.nested_ecological_effect <- function(
+  comm,
+  main_factor,
+  nested_factor,
+  method = "bray"
+) {
+  DistBC <- vegan::vegdist(comm, method = method)
+  ord <- vegan::wcmdscale(DistBC, eig = TRUE, add = "lingoes")
+
+  eig <- ord$eig
+  eig_pos <- which(eig > 0)
+  coords <- as.data.frame(ord$points[, eig_pos, drop = FALSE])
+  main_factor <- as.factor(main_factor)
+  nested_factor <- as.factor(nested_factor)
+
+  n_obs <- nrow(comm)
+  if (ncol(coords) == 0) {
+    pcoa_points <- data.frame(
+      sample_id = seq_len(n_obs),
+      group = main_factor,
+      nested = nested_factor,
+      Axis1 = rep(0, n_obs),
+      Axis2 = rep(0, n_obs),
+      stringsAsFactors = FALSE
+    )
+  } else if (ncol(coords) == 1) {
+    pcoa_points <- data.frame(
+      sample_id = seq_len(n_obs),
+      group = main_factor,
+      nested = nested_factor,
+      Axis1 = coords[[1]],
+      Axis2 = rep(0, n_obs),
+      stringsAsFactors = FALSE
+    )
+  } else {
+    pcoa_points <- data.frame(
+      sample_id = seq_len(n_obs),
+      group = main_factor,
+      nested = nested_factor,
+      Axis1 = coords[[1]],
+      Axis2 = coords[[2]],
+      stringsAsFactors = FALSE
+    )
+  }
+
+  coords_nested <- cbind(
+    data.frame(main = main_factor, nested = nested_factor),
+    coords
+  )
+
+  centroids_nested <- stats::aggregate(. ~ main + nested, data = coords_nested, FUN = mean)
+  centroids_main <- stats::aggregate(. ~ main, data = centroids_nested, FUN = mean)
+
+  centroid_main_mat <- as.matrix(centroids_main[, -(1), drop = FALSE])
+  dist_main_pairwise <- stats::dist(centroid_main_mat) |> as.matrix()
+  rownames(dist_main_pairwise) <- centroids_main$main
+  colnames(dist_main_pairwise) <- centroids_main$main
+
+  A <- nrow(centroids_main)
+  if (A >= 2) {
+    upper <- dist_main_pairwise[upper.tri(dist_main_pairwise)]
+    effect_ecol_main <- sqrt(mean(upper^2))
+  } else {
+    effect_ecol_main <- 0
+  }
+
+  centroids_with_main <- merge(
+    centroids_nested,
+    centroids_main,
+    by = "main",
+    suffixes = c("_nested", "_main")
+  )
+
+  axis_nested <- grep("_nested$", names(centroids_with_main), value = TRUE)
+  axis_main <- sub("_nested$", "_main", axis_nested)
+
+  d_to_main <- sqrt(rowSums(
+    (as.matrix(centroids_with_main[, axis_nested, drop = FALSE]) -
+      as.matrix(centroids_with_main[, axis_main, drop = FALSE]))^2
+  ))
+
+  disp_nested <- data.frame(
+    main = centroids_with_main$main,
+    nested = centroids_with_main$nested,
+    dist_to_main = d_to_main,
+    stringsAsFactors = FALSE
+  )
+
+  disp_nested_within_main <- stats::aggregate(
+    dist_to_main ~ main,
+    data = disp_nested,
+    FUN = mean
+  )
+
+  list(
+    ecological_effect = effect_ecol_main,
+    effect_ecol_main = effect_ecol_main,
+    centroids_nested = centroids_nested,
+    centroids_main_factor = centroids_main,
+    dist_main_pairwise = dist_main_pairwise,
+    disp_nested_within_main = disp_nested_within_main,
+    disp_nested_global = mean(disp_nested$dist_to_main),
+    pcoa_points = pcoa_points,
+    positive_axes = eig_pos
+  )
+}
+
+.balanced_sampling_es_nested <- function(
+  i,
+  Y,
+  mm,
+  nn,
+  YPU,
+  HaSim,
+  resultsHa,
+  factEnv,
+  n_species,
+  transformation,
+  method
+) {
+  m <- mm[i]
+  n <- nn[i]
+
+  df_idx <- tibble::tibble(
+    idx = seq_along(Y),
+    PU = YPU
+  )
+
+  psu_sel <- df_idx |>
+    dplyr::distinct(PU) |>
+    dplyr::slice_sample(n = m) |>
+    dplyr::pull(PU)
+
+  sel_rows <- df_idx |>
+    dplyr::filter(PU %in% psu_sel) |>
+    dplyr::group_by(PU) |>
+    dplyr::slice_sample(n = n / m) |>
+    dplyr::ungroup() |>
+    dplyr::pull(idx)
+
+  sel <- matrix(0L, nrow = nrow(df_idx), ncol = 1)
+  sel[sel_rows, 1] <- 1L
+  ones <- which(sel[, 1] %in% 1)
+
+  ya <- HaSim[ones, , resultsHa[i, 1]]
+  ya_comm <- as.matrix(ya[, seq_len(n_species), drop = FALSE])
+  fact_x <- factEnv[ones, , drop = FALSE]
+
+  infer_out <- dbmanova_nested(
+    x = ya_comm,
+    factEnv = fact_x,
+    transformation = transformation,
+    method = method,
+    model = "nested.symmetric",
+    return = "table"
+  )
+
+  eco <- .nested_ecological_effect(
+    comm = ya_comm,
+    main_factor = fact_x[, 1],
+    nested_factor = interaction(fact_x[, 1], fact_x[, 2], drop = TRUE),
+    method = method
+  )
+
+  R2 <- infer_out[1, "SS"] / infer_out[4, "SS"]
+  omega2 <- (infer_out[1, "SS"] - infer_out[1, "df"] * infer_out[2, "MS"]) /
+    (infer_out[4, "SS"] + infer_out[2, "MS"])
+
+  pcoa_points <- eco$pcoa_points
+  pcoa_points$dat_sim <- resultsHa[i, "dat.sim"]
+  pcoa_points$k <- resultsHa[i, "k"]
+  pcoa_points$m <- resultsHa[i, "m"]
+  pcoa_points$n <- resultsHa[i, "n"]
+
+  list(
+    pseudoF = infer_out[1, "pseudoF"],
+    omega2 = omega2,
+    R2 = R2,
+    SS_between = infer_out[1, "SS"],
+    SS_total = infer_out[4, "SS"],
+    df_between = infer_out[1, "df"],
+    MS_residual = infer_out[3, "MS"],
+    ecological_effect = eco$ecological_effect,
+    effect_ecol_main = eco$effect_ecol_main,
+    centroids_nested = eco$centroids_nested,
+    centroids_main_factor = eco$centroids_main_factor,
+    dist_main_pairwise = eco$dist_main_pairwise,
+    disp_nested_within_main = eco$disp_nested_within_main,
+    disp_nested_global = eco$disp_nested_global,
+    n_groups = nrow(eco$centroids_main_factor),
+    infer_table = infer_out,
+    pcoa_points = pcoa_points
+  )
+}
+
 sim_ES <- function(
   data,
   steps = 10,
@@ -105,19 +300,41 @@ sim_ES <- function(
   model = "single.factor",
   jitter.base = 0.5
 ) {
-  if (model != "single.factor") {
+  if (!model %in% c("single.factor", "nested.symmetric")) {
     stop(
-      "`sim_ES()` currently supports only `model = 'single.factor'`. Nested designs are not implemented yet."
+      "`model` must be either `single.factor` or `nested.symmetric`."
     )
   }
 
   # read data and store it in two objects, one for H0 and one for Ha ----
   datH0 <- data
-  datH0[, 1] <- as.factor("zero")
   datHa <- data
-  datHa[, 1] <- as.factor(data[, 1])
-  a <- nlevels(datHa[, 1])
-  M <- a
+
+  if (model == "single.factor") {
+    datH0[, 1] <- as.factor("zero")
+    datHa[, 1] <- as.factor(data[, 1])
+    a <- nlevels(datHa[, 1])
+    M <- a
+    n_species <- ncol(data) - 1
+    factEnv <- NULL
+  } else {
+    datH0[, 1] <- as.factor("zero")
+    datH0[, 2] <- as.factor(data[, 2])
+    datHa[, 1] <- as.factor(data[, 1])
+    datHa[, 2] <- as.factor(data[, 2])
+    trt_nested <- unique(data.frame(
+      main = datHa[, 1],
+      nested = datHa[, 2]
+    ))
+    a <- nlevels(as.factor(datHa[, 1]))
+    M <- nrow(trt_nested)
+    n_species <- ncol(data) - 2
+    factEnv <- trt_nested[rep(seq_len(nrow(trt_nested)), each = N), , drop = FALSE]
+  }
+
+  if (!is.null(m) && m > M) {
+    stop("`m` must be <= total number of nested units available in simulation (`M`).")
+  }
 
   ## Helper matrix to store labels ----
   NN <- cases * k * (n - 1)
@@ -133,7 +350,7 @@ sim_ES <- function(
 
   resultsHa[, 1] <- rep(seq(cases), times = 1, each = (k * (n - 1)))
   resultsHa[, 2] <- rep(1:k, times = (n - 1) * cases)
-  resultsHa[, 3] <- M
+  resultsHa[, 3] <- if (model == "nested.symmetric" && !is.null(m)) m else M
   resultsHa[, 4] <- rep(seq(2, n), times = 1, each = k)
 
   Y <- cbind(1:(N * M))
@@ -146,11 +363,17 @@ sim_ES <- function(
   parHa <- SSP::assempar(data = datHa, type = type, Sest.method = Sest.method)
 
   ## Calculate species similarity percentage from Ha ----
-  sppContribution <- use_simper(datHa)
+  simper_data <- if (model == "single.factor") {
+    datHa
+  } else {
+    cbind(datHa[, 1, drop = FALSE], datHa[, -(1:2), drop = FALSE])
+  }
+  sppContribution <- use_simper(simper_data)
 
   ## Output container ----
   resultOut <- vector("list", length = NN * (steps + 1))
   pcoaOut <- vector("list", length = NN * (steps + 1))
+  nestedDetailOut <- vector("list", length = NN * (steps + 1))
 
   simH0 <- SSP::simdata(
     parH0,
@@ -247,37 +470,21 @@ sim_ES <- function(
       parabar::export(
         cl,
         variables = c(
-          "balanced_sampling_es",
+          if (model == "single.factor") "balanced_sampling_es" else ".balanced_sampling_es_nested",
           "dbmanova_oneway",
+          "dbmanova_nested",
+          ".nested_ecological_effect",
           "calc_dist"
         ),
         environment = asNamespace("ecocbo")
       )
 
       # Executing the loop in parallel
-      result1 <- parabar::par_lapply(
-        cl,
-        x = 1:NN,
-        fun = balanced_sampling_es,
-        Y,
-        mm,
-        nn,
-        YPU,
-        HaSim,
-        resultsHa,
-        transformation,
-        method
-      )
-
-      parabar::stop_backend(cl)
-    } else {
-      pb <- txtProgressBar(max = NN, style = 3)
-      result1 <- vector("list", length = NN)
-
-      for (i in seq_len(NN)) {
-        # Performs the operation iteratively in a for loop
-        result1[[i]] <- balanced_sampling_es(
-          i,
+      result1 <- if (model == "single.factor") {
+        parabar::par_lapply(
+          cl,
+          x = 1:NN,
+          fun = balanced_sampling_es,
           Y,
           mm,
           nn,
@@ -287,6 +494,58 @@ sim_ES <- function(
           transformation,
           method
         )
+      } else {
+        parabar::par_lapply(
+          cl,
+          x = 1:NN,
+          fun = .balanced_sampling_es_nested,
+          Y,
+          mm,
+          nn,
+          YPU,
+          HaSim,
+          resultsHa,
+          factEnv,
+          n_species,
+          transformation,
+          method
+        )
+      }
+
+      parabar::stop_backend(cl)
+    } else {
+      pb <- txtProgressBar(max = NN, style = 3)
+      result1 <- vector("list", length = NN)
+
+      for (i in seq_len(NN)) {
+        # Performs the operation iteratively in a for loop
+        result1[[i]] <- if (model == "single.factor") {
+          balanced_sampling_es(
+            i,
+            Y,
+            mm,
+            nn,
+            YPU,
+            HaSim,
+            resultsHa,
+            transformation,
+            method
+          )
+        } else {
+          .balanced_sampling_es_nested(
+            i,
+            Y,
+            mm,
+            nn,
+            YPU,
+            HaSim,
+            resultsHa,
+            factEnv,
+            n_species,
+            transformation,
+            method
+          )
+        }
 
         # Updating the progress bar
         setTxtProgressBar(pb, i)
@@ -298,7 +557,8 @@ sim_ES <- function(
 
     resultOut[idx] <- lapply(seq_len(NN), function(i) {
       cur <- result1[[i]]
-      data.frame(
+
+      out <- data.frame(
         reduction_level = st / steps,
         step = st,
         dat_sim = resultsHa[i, "dat.sim"],
@@ -316,6 +576,13 @@ sim_ES <- function(
         n_groups = cur$n_groups,
         stringsAsFactors = FALSE
       )
+
+      if (model == "nested.symmetric") {
+        out$effect_ecol_main <- cur$effect_ecol_main
+        out$disp_nested_within_main <- cur$disp_nested_global
+      }
+
+      out
     })
 
     pcoaOut[idx] <- lapply(seq_len(NN), function(i) {
@@ -325,6 +592,24 @@ sim_ES <- function(
       pts$step <- st
       pts
     })
+
+    if (model == "nested.symmetric") {
+      nestedDetailOut[idx] <- lapply(seq_len(NN), function(i) {
+        cur <- result1[[i]]
+        list(
+          step = st,
+          reduction_level = st / steps,
+          dat_sim = resultsHa[i, "dat.sim"],
+          k = resultsHa[i, "k"],
+          m = resultsHa[i, "m"],
+          n = resultsHa[i, "n"],
+          centroids_nested = cur$centroids_nested,
+          centroids_main_factor = cur$centroids_main_factor,
+          dist_main_pairwise = cur$dist_main_pairwise,
+          disp_nested_within_main = cur$disp_nested_within_main
+        )
+      })
+    }
 
     cat("Step ", st, ": Done! - ", steps - st, " remaining")
   }
@@ -337,6 +622,10 @@ sim_ES <- function(
     pcoa = pcoaOut,
     call = match.call()
   )
+
+  if (model == "nested.symmetric") {
+    attr(es_obj, "nested_ecology") <- nestedDetailOut
+  }
 
   return(es_obj)
 }
@@ -496,6 +785,8 @@ print.effect_size_data <- function(
       "m",
       "n",
       "ecological_effect",
+      "effect_ecol_main",
+      "disp_nested_within_main",
       "omega2",
       "R2",
       "pseudoF"

--- a/tests/testthat/test-sim_es.R
+++ b/tests/testthat/test-sim_es.R
@@ -1,0 +1,114 @@
+test_that("nested ecological helper computes hierarchical outputs", {
+  skip_if_not_installed("vegan")
+
+  comm <- rbind(
+    c(8, 2, 0, 1),
+    c(7, 3, 0, 1),
+    c(1, 8, 2, 0),
+    c(0, 9, 1, 0),
+    c(6, 1, 0, 2),
+    c(5, 2, 0, 3)
+  )
+
+  main <- factor(c("A", "A", "B", "B", "A", "A"))
+  nested <- factor(c("s1", "s1", "s2", "s2", "s3", "s3"))
+
+  out <- ecocbo:::.nested_ecological_effect(
+    comm = comm,
+    main_factor = main,
+    nested_factor = nested,
+    method = "bray"
+  )
+
+  expect_true(is.list(out))
+  expect_true(all(
+    c(
+      "effect_ecol_main",
+      "centroids_nested",
+      "centroids_main_factor",
+      "dist_main_pairwise",
+      "disp_nested_within_main",
+      "disp_nested_global",
+      "pcoa_points"
+    ) %in% names(out)
+  ))
+  expect_true(is.numeric(out$effect_ecol_main))
+  expect_true(out$effect_ecol_main >= 0)
+  expect_true(nrow(out$centroids_nested) >= nrow(out$centroids_main_factor))
+})
+
+test_that("sim_ES single.factor remains backward compatible in core columns", {
+  skip_if_not_installed("SSP")
+  skip_if_not_installed("vegan")
+
+  data("epiDat", package = "ecocbo")
+
+  res <- sim_ES(
+    data = epiDat,
+    steps = 1,
+    type = "counts",
+    Sest.method = "average",
+    cases = 1,
+    N = 10,
+    n = 3,
+    k = 1,
+    transformation = "none",
+    method = "bray",
+    dummy = FALSE,
+    useParallel = FALSE,
+    model = "single.factor",
+    jitter.base = 0
+  )
+
+  expect_s3_class(res, "effect_size_data")
+  expect_true(all(c("ecological_effect", "omega2", "R2", "pseudoF") %in% names(res)))
+  expect_false("effect_ecol_main" %in% names(res))
+})
+
+test_that("sim_ES nested.symmetric returns hierarchical ecological outputs by step", {
+  skip_if_not_installed("SSP")
+  skip_if_not_installed("vegan")
+
+  data("dataFish", package = "ecocbo")
+
+  dat <- dataFish[, c(1, 2, 3:8)]
+  names(dat)[1:2] <- c("main", "nested")
+
+  # Build a symmetric subset: 2 main levels x 2 nested levels x 3 replicates
+  main_levels <- unique(dat$main)[1:2]
+  dat <- dat[dat$main %in% main_levels, , drop = FALSE]
+
+  key <- interaction(dat$main, dat$nested, drop = TRUE)
+  key_levels <- unique(key)
+  key_levels <- key_levels[seq_len(min(4, length(key_levels)))]
+  dat <- dat[key %in% key_levels, , drop = FALSE]
+
+  groups <- split(dat, interaction(dat$main, dat$nested, drop = TRUE))
+  min_n <- min(vapply(groups, nrow, numeric(1)))
+  dat_sym <- do.call(rbind, lapply(groups, function(x) x[seq_len(min(3, min_n)), , drop = FALSE]))
+  rownames(dat_sym) <- NULL
+
+  res <- sim_ES(
+    data = dat_sym,
+    steps = 2,
+    type = "cover",
+    Sest.method = "average",
+    cases = 1,
+    N = 6,
+    n = 3,
+    m = 2,
+    k = 1,
+    transformation = "none",
+    method = "bray",
+    dummy = FALSE,
+    useParallel = FALSE,
+    model = "nested.symmetric",
+    jitter.base = 0
+  )
+
+  expect_s3_class(res, "effect_size_data")
+  expect_true(all(c("effect_ecol_main", "disp_nested_within_main") %in% names(res)))
+  expect_true(is.list(attr(res, "nested_ecology")))
+  expect_true(length(unique(res$step)) == 3) # steps 0,1,2
+  expect_true(all(res$ecological_effect == res$effect_ecol_main))
+})


### PR DESCRIPTION
### Motivation
- Extend `sim_ES` to support balanced nested designs (`model = "nested.symmetric"`) and compute hierarchical ecological effect metrics for nested vs main factors.

### Description
- Implemented a PCoA-based helper `.nested_ecological_effect()` that computes centroids, pairwise main-factor distances, within-main nested dispersions, and returns PCoA points and positive axes. 
- Added `.balanced_sampling_es_nested()` to perform balanced sampling, run nested dbMANOVA (`dbmanova_nested`), compute inferential statistics and assemble nested ecological outputs per simulation. 
- Updated `sim_ES()` to accept `model = "single.factor"` or `"nested.symmetric"`, to prepare `datH0`/`datHa` for nested data, compute `factEnv`, branch the sampling routine and parallel exports, populate `resultsHa` appropriately, and attach nested details to the returned `effect_size_data` object. 
- Enhanced `print.effect_size_data()` preview columns to include `effect_ecol_main` and `disp_nested_within_main` when present, and added `tests/testthat/test-sim_es.R` with unit tests for the helper, backward compatibility for `single.factor`, and nested design behavior. 

### Testing
- Ran the new test file with `testthat` (the tests skip if `vegan` or `SSP` are not available) and all tests completed successfully in the CI-like environment. 
- Verified that `sim_ES(..., model = "single.factor")` remains backward compatible for core columns and that `sim_ES(..., model = "nested.symmetric")` returns hierarchical ecological outputs and an `nested_ecology` attribute. 
- Confirmed the added helper `.nested_ecological_effect()` returns the expected components and non-negative effect sizes when invoked with example community matrices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfdb5741388320935655be818bd0b4)