### PR TITLE
Document effect size plot arguments

### DIFF
--- a/R/methods_effect_size_data.R
+++ b/R/methods_effect_size_data.R
@@ -1056,11 +1056,39 @@ print.effect_size_data_nested <- function(
 #'   `reduction_level` or not.
 #' @param scatter_data Whether scatter should show raw observations
 #'   or summaries by `reduction_level`.
+#' @param reduction_levels Reduction levels to keep when `type = "ordination"`.
+#'   Passed to `.plot_effect_size_ordination()`.
+#' @param selection How to select representative ordinations per reduction level
+#'   when `type = "ordination"`; one of `"median"`, `"first"`, `"min"`, or
+#'   `"max"`. Passed to `.plot_effect_size_ordination()`.
+#' @param show_centroids Logical; show group centroids when
+#'   `type = "ordination"`. Passed to `.plot_effect_size_ordination()`.
+#' @param label_centroids Logical; label group centroids when
+#'   `type = "ordination"`. Passed to `.plot_effect_size_ordination()`.
 #' @param ribbon_alpha Alpha transparency for ribbons in stacked plots.
-#' @param point_alpha Alpha transparency for points in scatter plots.
+#' @param point_alpha Alpha transparency for points in scatter, ordination, and
+#'   True-H0 plots.
 #' @param line_size Line width in stacked plots.
 #' @param point_size Point size.
+#' @param centroid_size Point size for centroids when `type = "ordination"`.
+#'   Passed to `.plot_effect_size_ordination()`.
+#' @param facet_ncol Number of facet columns for ordination plots and for
+#'   True-H0 plots when `facet_effort = TRUE`.
 #' @param add_smooth Logical; add linear smooth to scatter plot.
+#' @param h0_alpha Significance level used to draw the dashed reference line
+#'   and to compute True-H0 pseudo-F critical values when `type = "true_h0"` or
+#'   `type = "ES_H0"`. Passed to `.plot_effect_size_true_h0()`.
+#' @param h0_x_var Variable to place on the x-axis of True-H0 plots; one of
+#'   `"pseudoF"`, `"ecological_effect"`, `"omega2"`, or `"R2"`. Passed to
+#'   `.plot_effect_size_true_h0()`.
+#' @param h0_color_by Variable used to color True-H0 points; one of
+#'   `"reduction_level"`, `"step"`, or `"none"`. Passed to
+#'   `.plot_effect_size_true_h0()`.
+#' @param facet_effort Logical; facet True-H0 plots by sampling effort (`m`,
+#'   `n`). Passed to `.plot_effect_size_true_h0()`.
+#' @param h0_quantile_type Quantile algorithm passed as `type` to
+#'   [stats::quantile()] when computing True-H0 pseudo-F critical values for
+#'   `type = "true_h0"` or `type = "ES_H0"`.
 #' @param ... Unused, reserved for future extensions.
 #'
 #' @return A ggplot object or a patchwork object.
@@ -1519,17 +1547,56 @@ summary.effect_size_data <- function(
 #'   `reduction_level` or not.
 #' @param scatter_data Whether scatter should show raw observations
 #'   or summaries by `reduction_level`.
-#' @param reduction_levels Reduction levels to keep in ordination plots.
-#' @param selection How to select representative ordinations per reduction level.
-#' @param show_centroids Logical; show centroids in ordination plot.
-#' @param label_centroids Logical; label centroids in ordination plot.
+#' @param reduction_levels Reduction levels to keep when `type = "ordination"`.
+#'   Passed through `.plot_effect_size_nested_ordination()` to
+#'   `.plot_effect_size_ordination()`.
+#' @param selection How to select representative ordinations per reduction level
+#'   when `type = "ordination"`; one of `"median"`, `"first"`, `"min"`, or
+#'   `"max"`. Passed through `.plot_effect_size_nested_ordination()` to
+#'   `.plot_effect_size_ordination()`.
+#' @param show_centroids Logical; show centroids when `type = "ordination"`.
+#'   Passed through `.plot_effect_size_nested_ordination()` to
+#'   `.plot_effect_size_ordination()`.
+#' @param label_centroids Logical; label centroids when `type = "ordination"`.
+#'   Passed through `.plot_effect_size_nested_ordination()` to
+#'   `.plot_effect_size_ordination()`.
 #' @param ribbon_alpha Alpha transparency for ribbons in stacked plots.
-#' @param point_alpha Alpha transparency for points in scatter plots.
+#' @param point_alpha Alpha transparency for points in scatter, ordination, and
+#'   True-H0 plots.
 #' @param line_size Line width in stacked plots.
 #' @param point_size Point size.
-#' @param centroid_size Point size for centroids in ordination plots.
-#' @param facet_ncol Number of columns in ordination faceting.
+#' @param centroid_size Point size for centroids when `type = "ordination"`.
+#'   Passed through `.plot_effect_size_nested_ordination()` to
+#'   `.plot_effect_size_ordination()`.
+#' @param facet_ncol Number of facet columns for ordination plots and for
+#'   True-H0 plots when `facet_effort = TRUE`.
 #' @param add_smooth Logical; add linear smooth to scatter plot.
+#' @param h0_alpha Significance level used to draw the dashed reference line
+#'   and to compute True-H0 pseudo-F critical values when `type = "true_h0"` or
+#'   `type = "ES_H0"`. Passed to `.plot_effect_size_nested_true_h0()`.
+#' @param h0_x_var Variable to place on the x-axis of True-H0 plots; one of
+#'   `"pseudoF"`, `"ecological_effect"`, `"omega2"`, or `"R2"`. Passed to
+#'   `.plot_effect_size_nested_true_h0()`.
+#' @param h0_color_by Variable used to color True-H0 points; one of
+#'   `"reduction_level"`, `"step"`, or `"none"`. Passed to
+#'   `.plot_effect_size_nested_true_h0()`.
+#' @param facet_effort Logical; facet True-H0 plots by sampling effort (`m`,
+#'   `n`). Passed to `.plot_effect_size_nested_true_h0()`.
+#' @param facet_subset Sampling-effort subset used when `facet_effort = TRUE`;
+#'   one of `"reduced"`, `"all"`, `"all_n"`, or `"all_m"`. Passed to
+#'   `.plot_effect_size_nested_true_h0()`.
+#' @param facet_start_at Starting sampling-effort value for the reduced
+#'   diagonal-and-tail facet path when `facet_subset = "reduced"`. Passed to
+#'   `.plot_effect_size_nested_true_h0()`.
+#' @param facet_m_value The `m` value to keep when `facet_subset = "all_n"`;
+#'   defaults to the maximum available `m` when `NULL`. Passed to
+#'   `.plot_effect_size_nested_true_h0()`.
+#' @param facet_n_value The `n` value to keep when `facet_subset = "all_m"`;
+#'   defaults to the maximum available `n` when `NULL`. Passed to
+#'   `.plot_effect_size_nested_true_h0()`.
+#' @param h0_quantile_type Quantile algorithm passed as `type` to
+#'   [stats::quantile()] when computing True-H0 pseudo-F critical values for
+#'   `type = "true_h0"` or `type = "ES_H0"`.
 #' @param ... Unused, reserved for future extensions.
 #'
 #' @return A ggplot object or a patchwork object.

--- a/man/plot.effect_size_data.Rd
+++ b/man/plot.effect_size_data.Rd
@@ -52,15 +52,54 @@ One of \code{"iqr"} or \code{"sd"}.}
 \item{scatter_data}{Whether scatter should show raw observations
 or summaries by \code{reduction_level}.}
 
+\item{reduction_levels}{Reduction levels to keep when \code{type = "ordination"}.
+Passed to \code{.plot_effect_size_ordination()}.}
+
+\item{selection}{How to select representative ordinations per reduction level
+when \code{type = "ordination"}; one of \code{"median"}, \code{"first"}, \code{"min"}, or
+\code{"max"}. Passed to \code{.plot_effect_size_ordination()}.}
+
+\item{show_centroids}{Logical; show group centroids when
+\code{type = "ordination"}. Passed to \code{.plot_effect_size_ordination()}.}
+
+\item{label_centroids}{Logical; label group centroids when
+\code{type = "ordination"}. Passed to \code{.plot_effect_size_ordination()}.}
+
 \item{ribbon_alpha}{Alpha transparency for ribbons in stacked plots.}
 
-\item{point_alpha}{Alpha transparency for points in scatter plots.}
+\item{point_alpha}{Alpha transparency for points in scatter, ordination, and
+True-H0 plots.}
 
 \item{line_size}{Line width in stacked plots.}
 
 \item{point_size}{Point size.}
 
+\item{centroid_size}{Point size for centroids when \code{type = "ordination"}.
+Passed to \code{.plot_effect_size_ordination()}.}
+
+\item{facet_ncol}{Number of facet columns for ordination plots and for
+True-H0 plots when \code{facet_effort = TRUE}.}
+
 \item{add_smooth}{Logical; add linear smooth to scatter plot.}
+
+\item{h0_alpha}{Significance level used to draw the dashed reference line
+and to compute True-H0 pseudo-F critical values when \code{type = "true_h0"} or
+\code{type = "ES_H0"}. Passed to \code{.plot_effect_size_true_h0()}.}
+
+\item{h0_x_var}{Variable to place on the x-axis of True-H0 plots; one of
+\code{"pseudoF"}, \code{"ecological_effect"}, \code{"omega2"}, or \code{"R2"}. Passed to
+\code{.plot_effect_size_true_h0()}.}
+
+\item{h0_color_by}{Variable used to color True-H0 points; one of
+\code{"reduction_level"}, \code{"step"}, or \code{"none"}. Passed to
+\code{.plot_effect_size_true_h0()}.}
+
+\item{facet_effort}{Logical; facet True-H0 plots by sampling effort (\code{m},
+\code{n}). Passed to \code{.plot_effect_size_true_h0()}.}
+
+\item{h0_quantile_type}{Quantile algorithm passed as \code{type} to
+\code{\link[stats:quantile]{stats::quantile()}} when computing True-H0 pseudo-F critical values for
+\code{type = "true_h0"} or \code{type = "ES_H0"}.}
 
 \item{...}{Unused, reserved for future extensions.}
 }

--- a/man/plot.effect_size_data_nested.Rd
+++ b/man/plot.effect_size_data_nested.Rd
@@ -60,27 +60,75 @@ One of \code{"iqr"} or \code{"sd"}.}
 \item{scatter_data}{Whether scatter should show raw observations
 or summaries by \code{reduction_level}.}
 
-\item{reduction_levels}{Reduction levels to keep in ordination plots.}
+\item{reduction_levels}{Reduction levels to keep when \code{type = "ordination"}.
+Passed through \code{.plot_effect_size_nested_ordination()} to
+\code{.plot_effect_size_ordination()}.}
 
-\item{selection}{How to select representative ordinations per reduction level.}
+\item{selection}{How to select representative ordinations per reduction level
+when \code{type = "ordination"}; one of \code{"median"}, \code{"first"}, \code{"min"}, or
+\code{"max"}. Passed through \code{.plot_effect_size_nested_ordination()} to
+\code{.plot_effect_size_ordination()}.}
 
-\item{show_centroids}{Logical; show centroids in ordination plot.}
+\item{show_centroids}{Logical; show centroids when \code{type = "ordination"}.
+Passed through \code{.plot_effect_size_nested_ordination()} to
+\code{.plot_effect_size_ordination()}.}
 
-\item{label_centroids}{Logical; label centroids in ordination plot.}
+\item{label_centroids}{Logical; label centroids when \code{type = "ordination"}.
+Passed through \code{.plot_effect_size_nested_ordination()} to
+\code{.plot_effect_size_ordination()}.}
 
 \item{ribbon_alpha}{Alpha transparency for ribbons in stacked plots.}
 
-\item{point_alpha}{Alpha transparency for points in scatter plots.}
+\item{point_alpha}{Alpha transparency for points in scatter, ordination, and
+True-H0 plots.}
 
 \item{line_size}{Line width in stacked plots.}
 
 \item{point_size}{Point size.}
 
-\item{centroid_size}{Point size for centroids in ordination plots.}
+\item{centroid_size}{Point size for centroids when \code{type = "ordination"}.
+Passed through \code{.plot_effect_size_nested_ordination()} to
+\code{.plot_effect_size_ordination()}.}
 
-\item{facet_ncol}{Number of columns in ordination faceting.}
+\item{facet_ncol}{Number of facet columns for ordination plots and for
+True-H0 plots when \code{facet_effort = TRUE}.}
 
 \item{add_smooth}{Logical; add linear smooth to scatter plot.}
+
+\item{h0_alpha}{Significance level used to draw the dashed reference line
+and to compute True-H0 pseudo-F critical values when \code{type = "true_h0"} or
+\code{type = "ES_H0"}. Passed to \code{.plot_effect_size_nested_true_h0()}.}
+
+\item{h0_x_var}{Variable to place on the x-axis of True-H0 plots; one of
+\code{"pseudoF"}, \code{"ecological_effect"}, \code{"omega2"}, or \code{"R2"}. Passed to
+\code{.plot_effect_size_nested_true_h0()}.}
+
+\item{h0_color_by}{Variable used to color True-H0 points; one of
+\code{"reduction_level"}, \code{"step"}, or \code{"none"}. Passed to
+\code{.plot_effect_size_nested_true_h0()}.}
+
+\item{facet_effort}{Logical; facet True-H0 plots by sampling effort (\code{m},
+\code{n}). Passed to \code{.plot_effect_size_nested_true_h0()}.}
+
+\item{facet_subset}{Sampling-effort subset used when \code{facet_effort = TRUE};
+one of \code{"reduced"}, \code{"all"}, \code{"all_n"}, or \code{"all_m"}. Passed to
+\code{.plot_effect_size_nested_true_h0()}.}
+
+\item{facet_start_at}{Starting sampling-effort value for the reduced
+diagonal-and-tail facet path when \code{facet_subset = "reduced"}. Passed to
+\code{.plot_effect_size_nested_true_h0()}.}
+
+\item{facet_m_value}{The \code{m} value to keep when \code{facet_subset = "all_n"};
+defaults to the maximum available \code{m} when \code{NULL}. Passed to
+\code{.plot_effect_size_nested_true_h0()}.}
+
+\item{facet_n_value}{The \code{n} value to keep when \code{facet_subset = "all_m"};
+defaults to the maximum available \code{n} when \code{NULL}. Passed to
+\code{.plot_effect_size_nested_true_h0()}.}
+
+\item{h0_quantile_type}{Quantile algorithm passed as \code{type} to
+\code{\link[stats:quantile]{stats::quantile()}} when computing True-H0 pseudo-F critical values for
+\code{type = "true_h0"} or \code{type = "ES_H0"}.}
 
 \item{...}{Unused, reserved for future extensions.}
 }


### PR DESCRIPTION
### Motivation
- Roxygen documentation for `plot.effect_size_data()` and `plot.effect_size_data_nested()` was missing several `@param` entries needed to document ordination and True-H0/ES_H0 behaviours.
- The missing entries caused the generated Rd files to omit `\item{...}` lines that must match the function `\usage`, making the help incomplete and potentially confusing for users.

### Description
- Added roxygen `@param` entries to `R/methods_effect_size_data.R` for `reduction_levels`, `selection`, `show_centroids`, `label_centroids`, `centroid_size`, `facet_ncol`, `h0_alpha`, `h0_x_var`, `h0_color_by`, `facet_effort`, and `h0_quantile_type` in `plot.effect_size_data()` with notes that ordination args are passed to `.plot_effect_size_ordination()` and True-H0 args are passed to `.plot_effect_size_true_h0()`.
- Added roxygen `@param` entries to `R/methods_effect_size_data.R` for `h0_alpha`, `h0_x_var`, `h0_color_by`, `facet_effort`, `facet_subset`, `facet_start_at`, `facet_m_value`, `facet_n_value`, and `h0_quantile_type` in `plot.effect_size_data_nested()` with notes that nested True-H0 args are passed to `.plot_effect_size_nested_true_h0()` and that nested ordination args are forwarded to `.plot_effect_size_ordination()`.
- Regenerated and/or updated the corresponding Rd files so that `man/plot.effect_size_data.Rd` and `man/plot.effect_size_data_nested.Rd` now include matching `\item{...}` entries for every argument listed in each function `\usage`.

### Testing
- Ran a Python-based check that parses each Rd `\usage{}` and verifies every usage argument has a matching `\item{...}`, and the check passed with no missing or extra items.
- Ran `git diff --check` to ensure no whitespace or diff check issues were introduced, and it returned clean.
- Attempted to run `devtools::document()` / `roxygen2::roxygenise()` via `Rscript`, but `Rscript` is not available in the current environment so full regeneration could not be executed; the Rd files were updated directly and verified for usage/item parity.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022b9c31808320ba523f0ccd345cff)